### PR TITLE
Remove unused component

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,2 @@
 [toolchain]
 channel = "1.58.0"
-components = ["rust-src"]


### PR DESCRIPTION
The rust-src component installs source code for the
rust compiler and stdlib, which isn't needed to build
openfare.